### PR TITLE
ci: set up CI using jacoco

### DIFF
--- a/petlog-api/build.gradle.kts
+++ b/petlog-api/build.gradle.kts
@@ -1,48 +1,98 @@
 plugins {
-	java
-	id("org.springframework.boot") version "3.1.8"
-	id("io.spring.dependency-management") version "1.1.4"
+    java
+    id("org.springframework.boot") version "3.1.8"
+    id("io.spring.dependency-management") version "1.1.4"
+    jacoco
 }
 
 group = "com.ppp"
 version = "0.0.1-SNAPSHOT"
 
 java {
-	sourceCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_17
 }
 
 configurations {
-	compileOnly {
-		extendsFrom(configurations.annotationProcessor.get())
-	}
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
+}
+
+jacoco {
+    toolVersion = "0.8.9"
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
-	implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-validation")
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
-	compileOnly("org.projectlombok:lombok")
-	runtimeOnly("com.h2database:h2")
-	runtimeOnly("com.mysql:mysql-connector-j")
-	annotationProcessor("org.projectlombok:lombok")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	implementation(project(":petlog-domain"))
-	implementation(project(":petlog-common"))
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation("org.springframework.data:spring-data-elasticsearch:5.1.8")
+    compileOnly("org.projectlombok:lombok")
+    runtimeOnly("com.h2database:h2")
+    runtimeOnly("com.mysql:mysql-connector-j")
+    annotationProcessor("org.projectlombok:lombok")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation(project(":petlog-domain"))
+    implementation(project(":petlog-common"))
 }
 
-tasks.withType<Test> {
-	useJUnitPlatform()
+tasks.test {
+    useJUnitPlatform()
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        html.required.set(true)
+    }
+    classDirectories.setFrom(
+        files(classDirectories.files.map {
+            fileTree(it) {
+                setIncludes(
+                    listOf(
+                        "com/ppp/**/controller/*",
+                        "com/ppp/**/service/*",
+                        "com/ppp/**/util/*",
+                        "com/ppp/**/interceptor/*"
+                    )
+                )
+            }
+        }))
+    finalizedBy(tasks.jacocoTestCoverageVerification)
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+    violationRules {
+        rule {
+			isEnabled = true
+			element = "CLASS"
+			includes = listOf(
+				"com.ppp.**.controller.*",
+				"com.ppp.**.service.*",
+				"com.ppp.**.util.*",
+				"com.ppp.**.interceptor.*"
+			)
+
+            limit {
+				minimum = "0.80".toBigDecimal()
+				counter = "LINE"
+				value = "COVEREDRATIO"
+            }
+        }
+    }
 }
 
 tasks.bootBuildImage {
-	builder.set("paketobuildpacks/builder-jammy-base:latest")
+    builder.set("paketobuildpacks/builder-jammy-base:latest")
 }
 
-tasks.register("prepareKotlinBuildScriptModel"){}
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/petlog-api/src/test/java/com/ppp/ApiApplicationTests.java
+++ b/petlog-api/src/test/java/com/ppp/ApiApplicationTests.java
@@ -1,13 +1,11 @@
 package com.ppp;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class ApiApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #1
> Jacoco 라이브러리를 활용해 CI를 구축합니다.

## 🔑 Key Changes
-  add Jacoco config on `/petlog-api/build.gradle.kts`

## 📢 To Reviewers
- 프로젝트 내 controller, util, service, interceptor가 테스트 코드 검증에 포함됩니다.
