### PR TITLE
feat: add diary API

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
@@ -1,0 +1,50 @@
+package com.ppp.api.diary.controller;
+
+import com.ppp.api.diary.dto.request.DiaryRequest;
+import com.ppp.api.diary.service.DiaryService;
+import com.ppp.domain.user.User;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/vi/pets")
+public class DiaryController {
+    private final DiaryService diaryService;
+
+    @PostMapping(value = "/{petId}/diaries")
+    private ResponseEntity<Void> createDiary(@PathVariable Long petId,
+                                             @Valid @RequestPart DiaryRequest request,
+                                             @Valid @RequestPart(required = false)
+                                             @Size(max = 10, message = "이미지는 10개 이하로 첨부해주세요.") List<MultipartFile> images,
+                                             @Valid @RequestPart(required = false)
+                                             @Size(max = 1, message = "동영상은 1개 이하로 첨부해주세요.") List<MultipartFile> videos) {
+        request.addMedias(images, videos);
+        diaryService.createDiary(new User(), petId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/diaries/{diaryId}")
+    private ResponseEntity<Void> updateDiary(@PathVariable Long diaryId,
+                                             @Valid @RequestPart DiaryRequest request,
+                                             @Valid @RequestPart(required = false)
+                                             @Size(max = 10, message = "이미지는 10개 이하로 첨부해주세요.") List<MultipartFile> images,
+                                             @Valid @RequestPart(required = false)
+                                             @Size(max = 1, message = "동영상은 1개 이하로 첨부해주세요.") List<MultipartFile> videos) {
+        request.addMedias(images, videos);
+        diaryService.updateDiary(new User(), diaryId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/diaries/{diaryId}")
+    private ResponseEntity<Void> deleteDiary(@PathVariable Long diaryId) {
+        diaryService.deleteDiary(new User(), diaryId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/request/DiaryRequest.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/request/DiaryRequest.java
@@ -1,0 +1,37 @@
+package com.ppp.api.diary.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DiaryRequest {
+    @Size(min = 1, max = 255, message = "1자 이상 255자 이하의 제목을 입력해주세요.")
+    private String title;
+
+    @Size(min = 1, max = 5000, message = "1자 이상 5000자 이하의 내용을 입력해주세요.")
+    private String content;
+
+    @PastOrPresent(message = "날짜를 확인해주세요.")
+    private LocalDate date;
+
+    @JsonIgnore
+    private List<MultipartFile> medias = new ArrayList<>();
+
+    public void addMedias(List<MultipartFile> images, List<MultipartFile> videos) {
+        if (images != null && !images.isEmpty())
+            medias.addAll(images);
+        if (videos != null && !videos.isEmpty())
+            medias.addAll(videos);
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/exception/DiaryException.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/exception/DiaryException.java
@@ -1,0 +1,15 @@
+package com.ppp.api.diary.exception;
+
+import lombok.Getter;
+
+@Getter
+public class DiaryException extends RuntimeException {
+    private final int status;
+    private final String code;
+
+    public DiaryException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getHttpStatus().value();
+        this.code = errorCode.name();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/exception/ErrorCode.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/exception/ErrorCode.java
@@ -1,0 +1,18 @@
+package com.ppp.api.diary.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    FORBIDDEN_PET_SPACE(HttpStatus.FORBIDDEN, "DIARY-0001","해당 기록 공간에 대한 권한이 없습니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "DIARY-0002","일치하는 일기가 없습니다."),
+    NOT_DIARY_OWNER(HttpStatus.BAD_REQUEST, "DIARY-0003", "일기 작성자가 아닙니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}
+

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryService.java
@@ -1,0 +1,63 @@
+package com.ppp.api.diary.service;
+
+import com.ppp.api.diary.dto.request.DiaryRequest;
+import com.ppp.api.diary.exception.DiaryException;
+import com.ppp.api.pet.exception.PetException;
+import com.ppp.domain.diary.Diary;
+import com.ppp.domain.diary.repository.DiaryRepository;
+import com.ppp.domain.pet.Pet;
+import com.ppp.domain.pet.repository.PetRepository;
+import com.ppp.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+import static com.ppp.api.diary.exception.ErrorCode.DIARY_NOT_FOUND;
+import static com.ppp.api.diary.exception.ErrorCode.NOT_DIARY_OWNER;
+import static com.ppp.api.pet.exception.ErrorCode.PET_NOT_FOUND;
+
+@RequiredArgsConstructor
+@Service
+public class DiaryService {
+    private final DiaryRepository diaryRepository;
+    private final PetRepository petRepository;
+
+    @Transactional
+    public void createDiary(User user, Long petId, DiaryRequest request) {
+        Pet pet = petRepository.findByIdAndIsDeletedFalse(petId)
+                .orElseThrow(() -> new PetException(PET_NOT_FOUND));
+        //TODO: check user has authority on pet space
+        //TODO: upload files to S3
+        diaryRepository.save(Diary.builder()
+                .title(request.getTitle())
+                .content(request.getContent())
+                .date(request.getDate())
+                .user(user)
+                .pet(pet)
+                .build());
+    }
+
+    @Transactional
+    public void updateDiary(User user, Long diaryId, DiaryRequest request) {
+        Diary diary = diaryRepository.findByIdAndIsDeletedFalse(diaryId)
+                .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
+        //TODO: check user has authority on pet space
+        //TODO: upload files to S3
+        diary.update(request.getTitle(), request.getContent(), request.getDate());
+    }
+
+    private void validateModifyDiary(Diary diary, User user) {
+        if (Objects.equals(diary.getUser().getId(), user.getId()))
+            throw new DiaryException(NOT_DIARY_OWNER);
+    }
+
+    public void deleteDiary(User user, Long diaryId) {
+        Diary diary = diaryRepository.findByIdAndIsDeletedFalse(diaryId)
+                .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
+        //TODO: check user has authority on pet space
+        validateModifyDiary(diary, user);
+        diary.delete();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryService.java
@@ -43,13 +43,14 @@ public class DiaryService {
     public void updateDiary(User user, Long diaryId, DiaryRequest request) {
         Diary diary = diaryRepository.findByIdAndIsDeletedFalse(diaryId)
                 .orElseThrow(() -> new DiaryException(DIARY_NOT_FOUND));
+        validateModifyDiary(diary, user);
         //TODO: check user has authority on pet space
         //TODO: upload files to S3
         diary.update(request.getTitle(), request.getContent(), request.getDate());
     }
 
     private void validateModifyDiary(Diary diary, User user) {
-        if (Objects.equals(diary.getUser().getId(), user.getId()))
+        if (!Objects.equals(diary.getUser().getId(), user.getId()))
             throw new DiaryException(NOT_DIARY_OWNER);
     }
 

--- a/petlog-api/src/main/java/com/ppp/api/exception/ErrorCode.java
+++ b/petlog-api/src/main/java/com/ppp/api/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.ppp.api.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    REQUEST_ARGUMENT_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL-0001", "request argument error");
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}
+

--- a/petlog-api/src/main/java/com/ppp/api/exception/GlobalExceptionHandler.java
+++ b/petlog-api/src/main/java/com/ppp/api/exception/GlobalExceptionHandler.java
@@ -1,12 +1,14 @@
 package com.ppp.api.exception;
 
 
+import com.ppp.api.diary.exception.DiaryException;
 import com.ppp.api.mock.exception.MockException;
+import com.ppp.api.pet.exception.PetException;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,11 +18,52 @@ import java.time.LocalDateTime;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     private static final String LOG_FORMAT = "Class : {}, Code : {}, Message : {}";
-    Logger defaultLog = LoggerFactory.getLogger(GlobalExceptionHandler.class);
-    Logger exceptionLog = LoggerFactory.getLogger("ExceptionLogger");
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        String errorMessage = exception.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .findFirst()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse(ErrorCode.REQUEST_ARGUMENT_ERROR.name());
+
+        ExceptionResponse errorResponse = ExceptionResponse.builder()
+                .code(HttpStatus.BAD_REQUEST.name())
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(errorMessage)
+                .timestamp(LocalDateTime.now())
+                .build();
+        log.warn(LOG_FORMAT, exception.getClass().getSimpleName(), errorResponse.getCode(), exception.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(DiaryException.class)
+    public ResponseEntity<ExceptionResponse> handleDiaryException(DiaryException exception) {
+        ExceptionResponse errorResponse = ExceptionResponse.builder()
+                .status(exception.getStatus())
+                .code(exception.getCode())
+                .message(exception.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        log.warn(LOG_FORMAT, exception.getClass().getSimpleName(), errorResponse.getCode(), exception.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(PetException.class)
+    public ResponseEntity<ExceptionResponse> handlePetException(PetException exception) {
+        ExceptionResponse errorResponse = ExceptionResponse.builder()
+                .status(exception.getStatus())
+                .code(exception.getCode())
+                .message(exception.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build();
+        log.warn(LOG_FORMAT, exception.getClass().getSimpleName(), errorResponse.getCode(), exception.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 
     @ExceptionHandler(MockException.class)
-    public ResponseEntity<ExceptionResponse> handleMockException(MockException exception){
+    public ResponseEntity<ExceptionResponse> handleMockException(MockException exception) {
         ExceptionResponse errorResponse = ExceptionResponse.builder()
                 .status(exception.getStatus())
                 .code(exception.getCode())
@@ -32,7 +75,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception){
+    public ResponseEntity<ExceptionResponse> handleCustomException(CustomException exception) {
         ExceptionResponse errorResponse = ExceptionResponse.builder()
                 .status(exception.getStatus())
                 .code(exception.getCode())
@@ -45,14 +88,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ExceptionResponse> handleException(Exception exception) {
-        defaultLog.error(exception.getMessage());
-        exceptionLog.error(exception.getMessage(), exception);
         ExceptionResponse errorResponse = ExceptionResponse.builder()
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
-                .code("internal_server_error")
+                .code(HttpStatus.INTERNAL_SERVER_ERROR.name())
                 .message(exception.getMessage())
                 .timestamp(LocalDateTime.now())
                 .build();
+        log.error(LOG_FORMAT, exception.getClass().getSimpleName(), errorResponse.getCode(), exception.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/pet/exception/ErrorCode.java
+++ b/petlog-api/src/main/java/com/ppp/api/pet/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.ppp.api.pet.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    PET_NOT_FOUND(HttpStatus.NOT_FOUND, "PET-0001", "일치하는 반려 동물이 없습니다.");
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}
+

--- a/petlog-api/src/main/java/com/ppp/api/pet/exception/PetException.java
+++ b/petlog-api/src/main/java/com/ppp/api/pet/exception/PetException.java
@@ -1,0 +1,15 @@
+package com.ppp.api.pet.exception;
+
+import lombok.Getter;
+
+@Getter
+public class PetException extends RuntimeException {
+    private final int status;
+    private final String code;
+
+    public PetException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.status = errorCode.getHttpStatus().value();
+        this.code = errorCode.name();
+    }
+}

--- a/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
@@ -1,0 +1,136 @@
+package com.ppp.api.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppp.api.diary.dto.request.DiaryRequest;
+import com.ppp.api.diary.service.DiaryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = DiaryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class DiaryControllerTest {
+    @MockBean
+    DiaryService diaryService;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static final String TOKEN = "Bearer token";
+
+    @Test
+    @DisplayName("일기 생성 성공")
+    void createDiary_success() throws Exception {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), new ArrayList<>());
+        //when
+        mockMvc.perform(multipart("/api/vi/pets/{petId}/diaries", 1L)
+                        .file(new MockMultipartFile("request", "json",
+                                MediaType.APPLICATION_JSON_VALUE,
+                                objectMapper.writeValueAsString(request).getBytes(StandardCharsets.UTF_8)))
+                        .file(new MockMultipartFile("images", "image.jpg",
+                                MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes()))
+                        .file(new MockMultipartFile("videos", "video.mp4",
+                                MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes()))
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @DisplayName("일기 생성 성공-file not required")
+    void createDiary_success_FILE_NOT_REQUIRED() throws Exception {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), new ArrayList<>());
+        //when
+        mockMvc.perform(multipart("/api/vi/pets/{petId}/diaries", 1L)
+                        .file(new MockMultipartFile("request", "json",
+                                MediaType.APPLICATION_JSON_VALUE,
+                                objectMapper.writeValueAsString(request).getBytes(StandardCharsets.UTF_8)))
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @DisplayName("일기 수정 성공")
+    void updateDiary_success() throws Exception {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), new ArrayList<>());
+        //when
+        mockMvc.perform(multipart("/api/vi/pets/diaries/{diaryId}", 1L)
+                        .file(new MockMultipartFile("request", "json",
+                                MediaType.APPLICATION_JSON_VALUE,
+                                objectMapper.writeValueAsString(request).getBytes(StandardCharsets.UTF_8)))
+                        .file(new MockMultipartFile("images", "image.jpg",
+                                MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes()))
+                        .file(new MockMultipartFile("videos", "video.mp4",
+                                MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes()))
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(httpServletRequest -> {
+                            httpServletRequest.setMethod("PUT");
+                            return httpServletRequest;
+                        })
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @DisplayName("일기 수정 성공-file not required")
+    void updateDiary_success_FILE_NOT_REQUIRED() throws Exception {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), new ArrayList<>());
+        //when
+        mockMvc.perform(multipart("/api/vi/pets/diaries/{diaryId}", 1L)
+                        .file(new MockMultipartFile("request", "json",
+                                MediaType.APPLICATION_JSON_VALUE,
+                                objectMapper.writeValueAsString(request).getBytes(StandardCharsets.UTF_8)))
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .with(httpServletRequest -> {
+                            httpServletRequest.setMethod("PUT");
+                            return httpServletRequest;
+                        })
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @DisplayName("일기 삭제 성공")
+    void deleteDiary_success() throws Exception {
+        mockMvc.perform(delete("/api/vi/pets/diaries/{diaryId}", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+}

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryServiceTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryServiceTest.java
@@ -1,0 +1,208 @@
+package com.ppp.api.diary.service;
+
+import com.ppp.api.diary.dto.request.DiaryRequest;
+import com.ppp.api.diary.exception.DiaryException;
+import com.ppp.api.pet.exception.PetException;
+import com.ppp.domain.diary.Diary;
+import com.ppp.domain.diary.repository.DiaryRepository;
+import com.ppp.domain.pet.Pet;
+import com.ppp.domain.pet.repository.PetRepository;
+import com.ppp.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ppp.api.diary.exception.ErrorCode.DIARY_NOT_FOUND;
+import static com.ppp.api.diary.exception.ErrorCode.NOT_DIARY_OWNER;
+import static com.ppp.api.pet.exception.ErrorCode.PET_NOT_FOUND;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DiaryServiceTest {
+    @Mock
+    private DiaryRepository diaryRepository;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @InjectMocks
+    private DiaryService diaryService;
+
+    User user = User.builder()
+            .id("randomstring").build();
+
+    Pet pet = Pet.builder()
+            .id(1L).build();
+
+    List<MultipartFile> images = List.of(
+            new MockMultipartFile("images", "image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes()),
+            new MockMultipartFile("images", "image.jpg",
+                    MediaType.IMAGE_JPEG_VALUE, "abcde".getBytes())
+    );
+
+    @Test
+    @DisplayName("일기 생성 성공")
+    void createDiary_success() {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), images);
+
+        given(petRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.of(pet));
+        //when
+        diaryService.createDiary(user, 1L, request);
+        ArgumentCaptor<Diary> diaryCaptor = ArgumentCaptor.forClass(Diary.class);
+        //then
+        verify(diaryRepository, times(1)).save(diaryCaptor.capture());
+        assertEquals(request.getTitle(), diaryCaptor.getValue().getTitle());
+        assertEquals(request.getContent(), diaryCaptor.getValue().getContent());
+        assertEquals(request.getDate(), diaryCaptor.getValue().getDate());
+        assertEquals(user.getId(), diaryCaptor.getValue().getUser().getId());
+        assertEquals(pet.getId(), diaryCaptor.getValue().getPet().getId());
+    }
+
+    @Test
+    @DisplayName("일기 생성 실패-pet not found")
+    void createDiary_fail_PET_NOT_FOUND() {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), images);
+
+        given(petRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        PetException exception = assertThrows(PetException.class, () -> diaryService.createDiary(user, 1L, request));
+        //then
+        assertEquals(PET_NOT_FOUND.name(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("일기 수정 성공")
+    void updateDiary_success() {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), images);
+        Diary diary = Diary.builder()
+                .title("우리집 고양이")
+                .content("츄르를 좋아해")
+                .date(LocalDate.of(2020, 11, 11))
+                .user(user)
+                .pet(pet).build();
+
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.of(diary));
+        //when
+        diaryService.updateDiary(user, 1L, request);
+        //then
+        assertEquals(request.getTitle(), diary.getTitle());
+        assertEquals(request.getContent(), diary.getContent());
+        assertEquals(request.getDate(), diary.getDate());
+    }
+
+    @Test
+    @DisplayName("일기 수정 실패-diary not found")
+    void updateDiary_fail_DIARY_NOT_FOUND() {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), images);
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        DiaryException exception = assertThrows(DiaryException.class, () -> diaryService.updateDiary(user, 1L, request));
+        //then
+        assertEquals(DIARY_NOT_FOUND.name(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("일기 수정 실패-not diary owner")
+    void updateDiary_fail_NOT_DIARY_OWNER() {
+        //given
+        DiaryRequest request =
+                new DiaryRequest("우리 강아지", "너무 귀엽당", LocalDate.now(), images);
+        User otherUser = User.builder()
+                .id("other-user").build();
+        Diary diary = Diary.builder()
+                .title("우리집 고양이")
+                .content("츄르를 좋아해")
+                .date(LocalDate.of(2020, 11, 11))
+                .user(otherUser)
+                .pet(pet).build();
+
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.of(diary));
+        //when
+        DiaryException exception = assertThrows(DiaryException.class, () -> diaryService.updateDiary(user, 1L, request));
+        //then
+        assertEquals(NOT_DIARY_OWNER.name(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("일기 삭제 성공")
+    void deleteDiary_success() {
+        //given
+        Diary diary = Diary.builder()
+                .title("우리집 고양이")
+                .content("츄르를 좋아해")
+                .date(LocalDate.of(2020, 11, 11))
+                .user(user)
+                .pet(pet).build();
+
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.of(diary));
+        //when
+        diaryService.deleteDiary(user, 1L);
+        //then
+        assertEquals(diary.getIsDeleted(), true);
+    }
+
+    @Test
+    @DisplayName("일기 수정 실패-diary not found")
+    void deleteDiary_fail_DIARY_NOT_FOUND() {
+        //given
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.empty());
+        //when
+        DiaryException exception = assertThrows(DiaryException.class, () -> diaryService.deleteDiary(user, 1L));
+        //then
+        assertEquals(DIARY_NOT_FOUND.name(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("일기 수정 실패-not diary owner")
+    void deleteDiary_fail_NOT_DIARY_OWNER() {
+        //given
+        User otherUser = User.builder()
+                .id("other-user").build();
+        Diary diary = Diary.builder()
+                .title("우리집 고양이")
+                .content("츄르를 좋아해")
+                .date(LocalDate.of(2020, 11, 11))
+                .user(otherUser)
+                .pet(pet).build();
+
+        given(diaryRepository.findByIdAndIsDeletedFalse(anyLong()))
+                .willReturn(Optional.of(diary));
+        //when
+        DiaryException exception = assertThrows(DiaryException.class, () -> diaryService.deleteDiary(user, 1L));
+        //then
+        assertEquals(NOT_DIARY_OWNER.name(), exception.getCode());
+    }
+
+}

--- a/petlog-domain/build.gradle.kts
+++ b/petlog-domain/build.gradle.kts
@@ -25,6 +25,7 @@ dependencyManagement {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/Diary.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/Diary.java
@@ -1,0 +1,73 @@
+package com.ppp.domain.diary;
+
+import com.ppp.domain.common.BaseTimeEntity;
+import com.ppp.domain.pet.Pet;
+import com.ppp.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Diary extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "blob", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    private String thumbnailUrl;
+
+    @Column(columnDefinition = "bit default 0")
+    private Boolean isDeleted;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "diary")
+    private List<DiaryMedia> diaryMedias = new ArrayList<>();
+
+    public void addThumbnail(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void update(String title, String content, LocalDate date) {
+        this.title = title;
+        this.content = content;
+        this.date = date;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
+    @Builder
+    public Diary(String title, String content, LocalDate date, Pet pet, User user) {
+        this.title = title;
+        this.content = content;
+        this.date = date;
+        this.pet = pet;
+        this.user = user;
+    }
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/DiaryMedia.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/DiaryMedia.java
@@ -1,0 +1,30 @@
+package com.ppp.domain.diary;
+
+import com.ppp.domain.common.BaseTimeEntity;
+import com.ppp.domain.diary.constant.DiaryMediaType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.FetchType.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class DiaryMedia extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String url;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DiaryMediaType type;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "diary_id", nullable = false)
+    private Diary diary;
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/constant/DiaryMediaType.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/constant/DiaryMediaType.java
@@ -1,0 +1,5 @@
+package com.ppp.domain.diary.constant;
+
+public enum DiaryMediaType {
+    VIDEO, IMAGE
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryMediaRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryMediaRepository.java
@@ -1,0 +1,10 @@
+package com.ppp.domain.diary.repository;
+
+import com.ppp.domain.diary.DiaryMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiaryMediaRepository extends JpaRepository<DiaryMedia, Long> {
+
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
@@ -1,0 +1,12 @@
+package com.ppp.domain.diary.repository;
+
+import com.ppp.domain.diary.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    Optional<Diary> findByIdAndIsDeletedFalse(Long id);
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/pet/repository/PetRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/pet/repository/PetRepository.java
@@ -1,0 +1,12 @@
+package com.ppp.domain.pet.repository;
+
+import com.ppp.domain.pet.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PetRepository extends JpaRepository<Pet, Long> {
+    Optional<Pet> findByIdAndIsDeletedFalse(Long id);
+}


### PR DESCRIPTION
## 🔎 PR Description
- Close #3
> 육아일기에 대한 생성, 수정, 삭제 엔드포인트를 구현합니다.

## 🔑 Key Changes
- add diary create, update, delete API
- handle error occurred in API request field validation

## 📢 To Reviewers
- Guardian 엔티티 추가된 후 검증 로직 추가 예정
- S3 스토리지 구축 후 파일 관련 로직 추가 예정
