### PR TITLE
feat: build diary retrieval api endpoint

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
@@ -1,6 +1,8 @@
 package com.ppp.api.diary.controller;
 
 import com.ppp.api.diary.dto.request.DiaryRequest;
+import com.ppp.api.diary.dto.response.DiaryDetailResponse;
+import com.ppp.api.diary.dto.response.DiaryGroupByDateResponse;
 import com.ppp.api.diary.service.DiaryService;
 import com.ppp.api.exception.ExceptionResponse;
 import com.ppp.common.security.PrincipalDetails;
@@ -14,6 +16,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -75,5 +78,19 @@ public class DiaryController {
                                              @AuthenticationPrincipal PrincipalDetails principalDetails) {
         diaryService.deleteDiary(principalDetails.getUser(), diaryId);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/diaries/{diaryId}")
+    private ResponseEntity<DiaryDetailResponse> displayDiary(@PathVariable Long diaryId,
+                                                             @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(diaryService.displayDiary(principalDetails.getUser(), diaryId));
+    }
+
+    @GetMapping(value = "/{petId}/diaries")
+    private ResponseEntity<Slice<DiaryGroupByDateResponse>> displayDiaries(@PathVariable Long petId,
+                                                                           @RequestParam(defaultValue = "0") int page,
+                                                                           @RequestParam(defaultValue = "5") int size,
+                                                                           @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(diaryService.displayDiaries(principalDetails.getUser(), petId, page, size));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/request/DiaryRequest.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/request/DiaryRequest.java
@@ -13,15 +13,15 @@ import java.time.LocalDate;
 @AllArgsConstructor
 @NoArgsConstructor
 public class DiaryRequest {
-    @Schema(description = "제목", nullable = false, example = "오늘은 공원에서 산책을 했어요")
+    @Schema(description = "제목", example = "오늘은 공원에서 산책을 했어요")
     @Size(min = 1, max = 255, message = "1자 이상 255자 이하의 제목을 입력해주세요.")
     private String title;
 
-    @Schema(description = "내용", nullable = false, example = "날씨가 좋아서 산책을 했답니다")
+    @Schema(description = "내용", example = "날씨가 좋아서 산책을 했답니다")
     @Size(min = 1, max = 5000, message = "1자 이상 5000자 이하의 내용을 입력해주세요.")
     private String content;
 
-    @Schema(description = "날짜", nullable = false, example = "2024-01-31")
+    @Schema(description = "날짜", example = "2024-01-31")
     @PastOrPresent(message = "날짜를 확인해주세요.")
     private LocalDate date;
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryDetailResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryDetailResponse.java
@@ -1,0 +1,36 @@
+package com.ppp.api.diary.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ppp.api.user.dto.response.UserResponse;
+import com.ppp.domain.diary.Diary;
+import com.ppp.domain.diary.DiaryMedia;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record DiaryDetailResponse(
+        Long diaryId,
+        String title,
+        String content,
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDate date,
+        List<String> images,
+        boolean isCurrentUserLiked,
+        UserResponse writer
+) {
+    public static DiaryDetailResponse from(Diary diary, String currentUserId) {
+        return DiaryDetailResponse.builder()
+                .diaryId(diary.getId())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .images(diary.getDiaryMedias().stream()
+                        .map(DiaryMedia::getPath)
+                        .collect(Collectors.toList()))
+                .date(diary.getDate())
+                .writer(UserResponse.from(diary.getUser(), currentUserId))
+                .build();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryGroupByDateResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryGroupByDateResponse.java
@@ -1,0 +1,25 @@
+package com.ppp.api.diary.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ppp.domain.diary.Diary;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record DiaryGroupByDateResponse(
+        @JsonFormat(pattern = "yyyy년 MM월 dd일 E요일")
+        LocalDate date,
+        List<DiaryResponse> diaries
+) {
+    public static DiaryGroupByDateResponse of(LocalDate date, List<Diary> diaries, String currentUserId) {
+        return DiaryGroupByDateResponse.builder()
+                .date(date)
+                .diaries(diaries.stream()
+                        .map(diary -> DiaryResponse.from(diary, currentUserId))
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryResponse.java
@@ -1,0 +1,26 @@
+package com.ppp.api.diary.dto.response;
+
+import com.ppp.api.user.dto.response.UserResponse;
+import com.ppp.domain.diary.Diary;
+import lombok.Builder;
+
+@Builder
+public record DiaryResponse(
+        Long diaryId,
+        String title,
+        String content,
+        String thumbnailPath,
+        boolean isCurrentUserLiked,
+        UserResponse writer,
+        int commentCount
+) {
+    public static DiaryResponse from(Diary diary, String currentUserId) {
+        return DiaryResponse.builder()
+                .diaryId(diary.getId())
+                .title(diary.getTitle())
+                .content(diary.getContent())
+                .thumbnailPath(diary.getThumbnailPath())
+                .writer(UserResponse.from(diary.getUser(), currentUserId))
+                .build();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/user/dto/response/UserResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/user/dto/response/UserResponse.java
@@ -1,0 +1,22 @@
+package com.ppp.api.user.dto.response;
+
+import com.ppp.domain.user.User;
+import lombok.Builder;
+
+import java.util.Objects;
+
+@Builder
+public record UserResponse(
+        String id,
+        String nickname,
+        String profilePath,
+        boolean isCurrentUser
+) {
+    public static UserResponse from(User user, String currentUserId) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .isCurrentUser(Objects.equals(user.getId(), currentUserId))
+                .build();
+    }
+}

--- a/petlog-api/src/main/resources/application-dev.yml
+++ b/petlog-api/src/main/resources/application-dev.yml
@@ -11,10 +11,12 @@ spring:
       max-request-size: 50MB
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/petlog?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
-    username: admin
-    password: admin
+    url: jdbc:mysql://ENC("jov8u4WoZ2gyhOI7n1fjNdZyXwu+bthSn9Nh7IbGk1Hq9rKPH/HZkCBC7LJGSQxdiwpb4tI5Qa4N2VhzsgGV8oeaQhzafRCQ")/petlog?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
+    username: ENC("uT5Scmzjid/mQarp8Wejpw==")
+    password: ENC("sR4oLGgaxiuRiiOaI2C7An8iyrp6csnM")
   jpa:
+    defer-datasource-initialization: true
+    database-platform: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
     properties:
       hibernate:
@@ -28,12 +30,12 @@ spring:
 cloud:
   aws:
     s3:
-      bucket: BUCKETNAME
+      bucket: ENC("DFq5C1E7ikVMVvEIAocccgRQALrs0lDK")
     credentials:
-      access-key: ACCESSKEY_STRING
-      secret-key: SECRETKEY_STRING
+      access-key: ENC("+RB2HYst5ZTFuVsESnhgCaUKHaAY+JFQIrUQnxmTZt4=")
+      secret-key: ENC("Ci5RcZkKwP6rjLy1JrXfbzBUCh3sIWAEwPG4YnXGI1ivU0M1dZy+JLkVI7vsqSDrdxtXapdoCS0=")
     region:
-      static: REGIONNAME
+      static: ENC("J+EuG/dqH+tZRQWsHMVQLTEplBxbZX6z")
       auto: false
     stack:
       auto: false

--- a/petlog-api/src/main/resources/application-local.yml
+++ b/petlog-api/src/main/resources/application-local.yml
@@ -30,12 +30,12 @@ spring:
 cloud:
   aws:
     s3:
-      bucket: BUCKET_NAME
+      bucket: ENC("DFq5C1E7ikVMVvEIAocccgRQALrs0lDK")
     credentials:
-      access-key: ACCESSKEY_STRING
-      secret-key: SECRETKEY_STRING
+      access-key: ENC("+RB2HYst5ZTFuVsESnhgCaUKHaAY+JFQIrUQnxmTZt4=")
+      secret-key: ENC("Ci5RcZkKwP6rjLy1JrXfbzBUCh3sIWAEwPG4YnXGI1ivU0M1dZy+JLkVI7vsqSDrdxtXapdoCS0=")
     region:
-      static: REGIONNAME
+      static: ENC("J+EuG/dqH+tZRQWsHMVQLTEplBxbZX6z")
       auto: false
     stack:
       auto: false

--- a/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
@@ -19,8 +19,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -136,6 +135,30 @@ class DiaryControllerTest {
     @DisplayName("일기 삭제 성공")
     void deleteDiary_success() throws Exception {
         mockMvc.perform(delete("/api/v1/pets/diaries/{diaryId}", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기 조회 성공")
+    void displayDiary_success() throws Exception {
+        mockMvc.perform(get("/api/v1/pets/diaries/{diaryId}", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기 리스트 조회 성공")
+    void displayDiaries_success() throws Exception {
+        mockMvc.perform(get("/api/v1/pets/diaries/{diaryId}", 1L)
+                        .param("page", "0")
+                        .param("size", "10")
                         .header("Authorization", TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
@@ -1,6 +1,8 @@
 package com.ppp.domain.diary.repository;
 
 import com.ppp.domain.diary.Diary;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import java.util.Optional;
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Diary> findByIdAndIsDeletedFalse(Long id);
+    Slice<Diary> findByPetIdAndIsDeletedFalseOrderByIdDesc(Long petId, PageRequest pageRequest);
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #18
> 육아일기에 대한 조회 엔드포인트를 구현합니다.

## 🔑 Key Changes
- add diary retrieval API
- encrypt critical variable in yml by using Jasypt

## 📢 To Reviewers
- `application.yml` 암호화해서 올렸습니다. 확인 부탁드립니다.
