### PR TITLE
feat: add the like feature

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/config/CacheConfig.java
+++ b/petlog-api/src/main/java/com/ppp/api/config/CacheConfig.java
@@ -14,8 +14,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 
-import static com.ppp.domain.common.constant.CacheValue.DIARY_COMMENT_COUNT;
-import static com.ppp.domain.common.constant.CacheValue.PET_SPACE_AUTHORITY;
+import static com.ppp.domain.common.constant.CacheValue.*;
 
 @EnableCaching
 @Configuration
@@ -44,6 +43,8 @@ public class CacheConfig {
                 .withCacheConfiguration(PET_SPACE_AUTHORITY.getValue(),
                         RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(30)))
                 .withCacheConfiguration(DIARY_COMMENT_COUNT.getValue(),
-                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(60)));
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(60)))
+                .withCacheConfiguration(DIARY_COMMENT_LIKE_COUNT.getValue(),
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(30)));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryCommentController.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryCommentController.java
@@ -81,4 +81,12 @@ public class DiaryCommentController {
         return ResponseEntity
                 .ok(diaryCommentService.displayComments(principalDetails.getUser(), petId, diaryId));
     }
+
+    @PostMapping(value = "/comments/{commentId}/like")
+    private ResponseEntity<Void> likeComment(@PathVariable Long petId,
+                                             @PathVariable Long commentId,
+                                             @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        diaryCommentService.likeComment(principalDetails.getUser(), petId, commentId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/controller/DiaryController.java
@@ -106,4 +106,12 @@ public class DiaryController {
                                                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
         return ResponseEntity.ok(diaryService.displayDiaries(principalDetails.getUser(), petId, page, size));
     }
+
+    @PostMapping(value = "/{diaryId}/like")
+    private ResponseEntity<Void> likeComment(@PathVariable Long petId,
+                                             @PathVariable Long diaryId,
+                                             @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        diaryService.likeDiary(principalDetails.getUser(), petId, diaryId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryCommentResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryCommentResponse.java
@@ -14,17 +14,20 @@ public record DiaryCommentResponse(
         String content,
         String createdAt,
         boolean isCurrentUserLiked,
+        int likeCount,
         UserResponse writer,
         List<UserResponse> taggedUsers
 ) {
-    public static DiaryCommentResponse from(DiaryComment comment, String currentUserId) {
+    public static DiaryCommentResponse from(DiaryComment comment, String currentUserId, boolean isCurrentUserLiked, int likeCount) {
         return DiaryCommentResponse.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())
                 .createdAt(TimeUtil.calculateTerm(comment.getCreatedAt()))
                 .writer(UserResponse.from(comment.getUser(), currentUserId))
+                .isCurrentUserLiked(isCurrentUserLiked)
+                .likeCount(likeCount)
                 .taggedUsers(comment.getTaggedUsersIdNicknameMap().keySet()
-                        .stream().map(id -> UserResponse.of(id,
+                        .stream().map(id -> com.ppp.api.user.dto.response.UserResponse.of(id,
                                 comment.getTaggedUsersIdNicknameMap().get(id), currentUserId))
                         .collect(Collectors.toList()))
                 .build();

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryDetailResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryDetailResponse.java
@@ -20,9 +20,10 @@ public record DiaryDetailResponse(
         List<String> images,
         boolean isCurrentUserLiked,
         UserResponse writer,
-        int commentCount
+        int commentCount,
+        int likeCount
 ) {
-    public static DiaryDetailResponse from(Diary diary, String currentUserId, int commentCount) {
+    public static DiaryDetailResponse from(Diary diary, String currentUserId, int commentCount, boolean isCurrentUserLiked, int likeCount) {
         return DiaryDetailResponse.builder()
                 .diaryId(diary.getId())
                 .title(diary.getTitle())
@@ -32,6 +33,8 @@ public record DiaryDetailResponse(
                         .map(DiaryMedia::getPath)
                         .collect(Collectors.toList()))
                 .date(diary.getDate())
+                .isCurrentUserLiked(isCurrentUserLiked)
+                .likeCount(likeCount)
                 .writer(UserResponse.from(diary.getUser(), currentUserId))
                 .build();
     }

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryCommentService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryCommentService.java
@@ -12,6 +12,7 @@ import com.ppp.domain.user.User;
 import com.ppp.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
@@ -24,13 +25,14 @@ import static com.ppp.api.diary.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class DiaryCommentService {
 
     private final DiaryCommentRepository diaryCommentRepository;
     private final DiaryRepository diaryRepository;
     private final GuardianRepository guardianRepository;
     private final UserRepository userRepository;
-    private final DiaryCommentCountRedisService diaryCommentCountService;
+    private final DiaryCommentRedisService diaryCommentRedisService;
 
     public void createComment(User user, Long petId, Long diaryId, DiaryCommentRequest request) {
         Diary diary = diaryRepository.findByIdAndIsDeletedFalse(diaryId)
@@ -43,7 +45,7 @@ public class DiaryCommentService {
                 .diary(diary)
                 .user(user)
                 .build());
-        diaryCommentCountService.increaseDiaryCommentCountByDiaryId(diaryId);
+        diaryCommentRedisService.increaseDiaryCommentCountByDiaryId(diaryId);
     }
 
     private Map<String, String> getTaggedUsersIdNicknameMap(DiaryCommentRequest request) {
@@ -84,7 +86,8 @@ public class DiaryCommentService {
         validateModifyComment(comment, user, petId);
 
         comment.delete();
-        diaryCommentCountService.decreaseDiaryCommentCountByDiaryId(comment.getDiary().getId());
+        diaryCommentRedisService.decreaseDiaryCommentCountByDiaryId(comment.getDiary().getId());
+        diaryCommentRedisService.deleteAllLikeByCommentId(commentId);
     }
 
     public List<DiaryCommentResponse> displayComments(User user, Long petId, Long diaryId) {
@@ -93,7 +96,9 @@ public class DiaryCommentService {
         validateDisplayComments(user, petId);
 
         return diaryCommentRepository.findByDiaryAndIsDeletedFalse(diary).stream()
-                .map(comment -> DiaryCommentResponse.from(comment, user.getId()))
+                .map(comment -> DiaryCommentResponse.from(comment, user.getId(),
+                        diaryCommentRedisService.isDiaryCommentLikeExistByCommentIdAndUserId(comment.getId(), user.getId()),
+                        diaryCommentRedisService.getLikeCountByCommentId(comment.getId())))
                 .collect(Collectors.toList());
     }
 
@@ -101,4 +106,21 @@ public class DiaryCommentService {
         if (!guardianRepository.existsByUserIdAndPetId(user.getId(), petId))
             throw new DiaryException(FORBIDDEN_PET_SPACE);
     }
+
+    public void likeComment(User user, Long petId, Long commentId) {
+        validateLikeComment(user, petId, commentId);
+
+        if (diaryCommentRedisService.isDiaryCommentLikeExistByCommentIdAndUserId(commentId, user.getId()))
+            diaryCommentRedisService.cancelLikeByCommentIdAndUserId(commentId, user.getId());
+        else
+            diaryCommentRedisService.registerLikeByCommentIdAndUserId(commentId, user.getId());
+    }
+
+    private void validateLikeComment(User user, Long petId, Long commentId) {
+        if (!diaryCommentRepository.existsByIdAndIsDeletedFalse(commentId))
+            throw new DiaryException(DIARY_COMMENT_NOT_FOUND);
+        if (!guardianRepository.existsByUserIdAndPetId(user.getId(), petId))
+            throw new DiaryException(FORBIDDEN_PET_SPACE);
+    }
+
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryRedisService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryRedisService.java
@@ -1,0 +1,50 @@
+package com.ppp.api.diary.service;
+
+import com.ppp.common.client.RedisClient;
+import com.ppp.domain.common.constant.Domain;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiaryRedisService {
+    private final RedisClient redisClient;
+
+    public boolean isLikeExistByDiaryIdAndUserId(Long diaryId, String userId) {
+        return redisClient.isValueExistInSet(Domain.DIARY, diaryId, userId);
+    }
+
+    @Cacheable(value = "diaryLikeCount")
+    public Integer getLikeCountByDiaryId(Long diaryId) {
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        assert likeCount != null;
+
+        return likeCount.intValue();
+    }
+
+    @CachePut(value = "diaryLikeCount", key = "#a0")
+    public Integer registerLikeByDiaryIdAndUserId(Long diaryId, String userId) {
+        redisClient.addValueToSet(Domain.DIARY, diaryId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        assert likeCount != null;
+
+        return likeCount.intValue();
+    }
+
+    @CachePut(value = "diaryLikeCount", key = "#a0")
+    public Integer cancelLikeByDiaryIdAndUserId(Long diaryId, String userId) {
+        redisClient.removeValueToSet(Domain.DIARY, diaryId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        assert likeCount != null;
+
+        return likeCount.intValue();
+    }
+
+    @CacheEvict(value = "diaryLikeCount")
+    public void deleteAllLikeByDiaryId(Long diaryId) {
+        redisClient.removeKeyToSet(Domain.DIARY, diaryId);
+    }
+}

--- a/petlog-api/src/test/java/com/ppp/api/config/CacheIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/config/CacheIntegrationTest.java
@@ -32,15 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest(classes = ApiApplication.class)
 public class CacheIntegrationTest {
     @Autowired
-    CacheManager cacheManager;
+    private CacheManager cacheManager;
 
     @Autowired
-    PetRepository petRepository;
+    private PetRepository petRepository;
 
     @Autowired
-    UserRepository userRepository;
+    private UserRepository userRepository;
+
     @Autowired
-    GuardianRepository guardianRepository;
+    private GuardianRepository guardianRepository;
 
     @MockBean(JasyptConfig.class)
     private JasyptConfig jasyptConfig;

--- a/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryCommentControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryCommentControllerTest.java
@@ -44,7 +44,7 @@ class DiaryCommentControllerTest {
     @Test
     @WithMockCustomUser
     @DisplayName("일기 댓글 생성 성공")
-    void createDiaryComment_success() throws Exception {
+    void createComment_success() throws Exception {
         //given
         DiaryCommentRequest request =
                 new DiaryCommentRequest("오늘은 김밥을 먹었어요", List.of("abcde553", "qwerty1243"));
@@ -61,7 +61,7 @@ class DiaryCommentControllerTest {
     @Test
     @WithMockCustomUser
     @DisplayName("일기 댓글 수정 성공")
-    void updateDiaryComment_success() throws Exception {
+    void updateComment_success() throws Exception {
         //given
         DiaryCommentRequest request =
                 new DiaryCommentRequest("오늘은 김밥을 먹었어요", List.of("abcde553", "qwerty1243"));
@@ -78,7 +78,7 @@ class DiaryCommentControllerTest {
     @Test
     @WithMockCustomUser
     @DisplayName("일기 댓글 삭제 성공")
-    void deleteDiaryComment_success() throws Exception {
+    void deleteComment_success() throws Exception {
         //given
         //when
         mockMvc.perform(delete("/api/v1/pets/{petId}/diaries/comments/{commentId}", 1L, 1L)
@@ -92,10 +92,24 @@ class DiaryCommentControllerTest {
     @Test
     @WithMockCustomUser
     @DisplayName("일기 댓글 조회 성공")
-    void displayDiaryComment_success() throws Exception {
+    void displayComment_success() throws Exception {
         //given
         //when
         mockMvc.perform(get("/api/v1/pets/{petId}/diaries/{diaryId}/comments", 1L, 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기 댓글 좋아요 성공")
+    void likeComment_success() throws Exception {
+        //given
+        //when
+        mockMvc.perform(post("/api/v1/pets/{petId}/diaries/comments/{commentId}/like", 1L, 1L)
                         .header("Authorization", TOKEN)
                         .contentType(MediaType.APPLICATION_JSON_VALUE)
                 ).andDo(print())

--- a/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/controller/DiaryControllerTest.java
@@ -168,4 +168,15 @@ class DiaryControllerTest {
                 .andExpect(status().isOk());
         //then
     }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기 좋아요 성공")
+    void likeDiary_success() throws Exception {
+        mockMvc.perform(post("/api/v1/pets/{petId}/diaries/{diaryId}/like", 1L, 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+    }
 }

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceIntegrationTest.java
@@ -1,0 +1,192 @@
+package com.ppp.api.diary.service;
+
+import com.ppp.ApiApplication;
+import com.ppp.common.client.RedisClient;
+import com.ppp.common.config.JasyptConfig;
+import com.ppp.domain.common.constant.Domain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.ppp.domain.common.constant.CacheValue.DIARY_COMMENT_COUNT;
+import static com.ppp.domain.common.constant.CacheValue.DIARY_COMMENT_LIKE_COUNT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ApiApplication.class)
+class DiaryCommentRedisServiceIntegrationTest {
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private DiaryCommentRedisService diaryCommentRedisService;
+
+    @MockBean(JasyptConfig.class)
+    private JasyptConfig jasyptConfig;
+
+    @MockBean
+    private RedisClient redisClient;
+
+    @AfterEach
+    void tearDown() {
+        Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_COUNT.getValue()))
+                .evictIfPresent("1");
+        Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .evictIfPresent("1");
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 개수 캐싱 성공")
+    void cachingGetDiaryCommentCountByDiaryId_success() {
+        //given
+        given(redisClient.getValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(Optional.of("1"));
+        //when
+        Integer cacheMiss = diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
+        Integer cacheHit = diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        verify(redisClient, times(1)).getValue(any(), anyLong());
+        assertEquals(cacheMiss, cacheHit);
+        assertEquals(cacheMiss, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 개수 캐싱 삭제 성공")
+    void cachingDeleteDiaryCommentCountByDiaryId_success() {
+        //given
+        given(redisClient.getValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(Optional.of("1"));
+        //when
+        diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
+        diaryCommentRedisService.deleteDiaryCommentCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertNull(cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 개수 캐싱 업데이트 성공")
+    void cachingIncreaseDiaryCommentCountByDiaryId_success() {
+        //given
+        given(redisClient.getValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(Optional.of("1"));
+        given(redisClient.incrementValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(2L);
+        //when
+        diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
+        diaryCommentRedisService.increaseDiaryCommentCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_COUNT.getValue()))
+                .get("1", Integer.class);
+        //then
+        assertEquals(2, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 개수 캐싱 업데이트 성공")
+    void cachingDecreaseDiaryCommentCountByDiaryId_success() {
+        //given
+        given(redisClient.getValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(Optional.of("1"));
+        given(redisClient.decrementValue(Domain.DIARY_COMMENT, 1L))
+                .willReturn(0L);
+        //when
+        diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
+        diaryCommentRedisService.decreaseDiaryCommentCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(0, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 좋아요 개수 캐싱 성공")
+    void cachingGetLikeCountByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+                .willReturn(1L);
+        //when
+        Integer cacheMiss = diaryCommentRedisService.getLikeCountByCommentId(1L);
+        Integer cacheHit = diaryCommentRedisService.getLikeCountByCommentId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        verify(redisClient, times(1)).getSizeOfSet(any(), anyLong());
+        assertEquals(cacheMiss, cacheHit);
+        assertEquals(cacheMiss, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 좋아요 개수 캐싱 업데이트 성공")
+    void cachingRegisterLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheUpdated = diaryCommentRedisService.registerLikeByCommentIdAndUserId(1L, "abcde");
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheUpdated, 3);
+        assertEquals(cacheUpdated, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 좋아요 개수 캐싱 업데이트 성공")
+    void cachingCancelLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheUpdated = diaryCommentRedisService.cancelLikeByCommentIdAndUserId(1L, "abcde");
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheUpdated, 3);
+        assertEquals(cacheUpdated, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 댓글 좋아요 캐시 삭제 성공")
+    void deleteAllLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheMiss = diaryCommentRedisService.getLikeCountByCommentId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+        diaryCommentRedisService.deleteAllLikeByCommentId(1L);
+        Integer deleted = Objects.requireNonNull(cacheManager.getCache(DIARY_COMMENT_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheMiss, 3);
+        assertEquals(cached, 3);
+        assertNull(deleted);
+    }
+
+}

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceTest.java
@@ -16,12 +16,12 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
-class DiaryCommentCountRedisServiceTest {
+class DiaryCommentRedisServiceTest {
     @Mock
     private RedisClient redisClient;
 
     @InjectMocks
-    private DiaryCommentCountRedisService diaryCommentCountRedisService;
+    private DiaryCommentRedisService diaryCommentRedisService;
 
     @Test
     @DisplayName("다이어리 댓글 개수 조회 성공")
@@ -30,7 +30,7 @@ class DiaryCommentCountRedisServiceTest {
         given(redisClient.getValue(any(), anyLong()))
                 .willReturn(Optional.of("3"));
         //when
-        Integer result = diaryCommentCountRedisService.getDiaryCommentCountByDiaryId(1L);
+        Integer result = diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
         //then
         assertEquals(result, 3);
     }
@@ -42,7 +42,7 @@ class DiaryCommentCountRedisServiceTest {
         given(redisClient.getValue(any(), anyLong()))
                 .willReturn(Optional.empty());
         //when
-        Integer result = diaryCommentCountRedisService.getDiaryCommentCountByDiaryId(1L);
+        Integer result = diaryCommentRedisService.getDiaryCommentCountByDiaryId(1L);
         //then
         assertEquals(result, 0);
     }

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryRedisServiceIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryRedisServiceIntegrationTest.java
@@ -1,0 +1,118 @@
+package com.ppp.api.diary.service;
+
+import com.ppp.ApiApplication;
+import com.ppp.common.client.RedisClient;
+import com.ppp.common.config.JasyptConfig;
+import com.ppp.domain.common.constant.Domain;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Objects;
+
+import static com.ppp.domain.common.constant.CacheValue.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = ApiApplication.class)
+class DiaryRedisServiceIntegrationTest {
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private DiaryRedisService diaryRedisService;
+
+    @MockBean(JasyptConfig.class)
+    private JasyptConfig jasyptConfig;
+
+    @MockBean
+    private RedisClient redisClient;
+
+    @AfterEach
+    void tearDown() {
+        Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .evictIfPresent("1");
+    }
+
+    @Test
+    @DisplayName("다이어리 좋아요 개수 캐싱 성공")
+    void cachingGetLikeCountByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+                .willReturn(1L);
+        //when
+        Integer cacheMiss = diaryRedisService.getLikeCountByDiaryId(1L);
+        Integer cacheHit = diaryRedisService.getLikeCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        verify(redisClient, times(1)).getSizeOfSet(any(), anyLong());
+        assertEquals(cacheMiss, cacheHit);
+        assertEquals(cacheMiss, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 좋아요 개수 캐싱 업데이트 성공")
+    void cachingRegisterLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheUpdated = diaryRedisService.registerLikeByDiaryIdAndUserId(1L, "abcde");
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheUpdated, 3);
+        assertEquals(cacheUpdated, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 좋아요 개수 캐싱 업데이트 성공")
+    void cachingCancelLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheUpdated = diaryRedisService.cancelLikeByDiaryIdAndUserId(1L, "abcde");
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheUpdated, 3);
+        assertEquals(cacheUpdated, cached);
+    }
+
+    @Test
+    @DisplayName("다이어리 좋아요 캐시 삭제 성공")
+    void deleteAllLikeByCommentId_success() {
+        //given
+        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+                .willReturn(3L);
+        //when
+        Integer cacheMiss = diaryRedisService.getLikeCountByDiaryId(1L);
+        Integer cached = Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+        diaryRedisService.deleteAllLikeByDiaryId(1L);
+        Integer deleted = Objects.requireNonNull(cacheManager.getCache(DIARY_LIKE_COUNT.getValue()))
+                .get("1", Integer.class);
+
+        //then
+        assertEquals(cacheMiss, 3);
+        assertEquals(cached, 3);
+        assertNull(deleted);
+    }
+
+}

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryServiceTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryServiceTest.java
@@ -43,17 +43,16 @@ import static org.mockito.Mockito.verify;
 class DiaryServiceTest {
     @Mock
     private DiaryRepository diaryRepository;
-
     @Mock
     private PetRepository petRepository;
-
     @Mock
     private FileManageService fileManageService;
     @Mock
     private GuardianRepository guardianRepository;
     @Mock
-    private DiaryCommentCountRedisService diaryCommentCountRedisService;
-
+    private DiaryCommentRedisService diaryCommentRedisService;
+    @Mock
+    private DiaryRedisService diaryRedisService;
     @InjectMocks
     private DiaryService diaryService;
 
@@ -315,8 +314,11 @@ class DiaryServiceTest {
                 .willReturn(Optional.of(diary));
         given(guardianRepository.existsByUserIdAndPetId(user.getId(), pet.getId()))
                 .willReturn(true);
-        given(diaryCommentCountRedisService.getDiaryCommentCountByDiaryId(anyLong()))
+        given(diaryCommentRedisService.getDiaryCommentCountByDiaryId(anyLong()))
                 .willReturn(3);
+        given(diaryRedisService.isLikeExistByDiaryIdAndUserId(anyLong(), anyString()))
+                .willReturn(false);
+        given(diaryRedisService.getLikeCountByDiaryId(anyLong())).willReturn(5);
         //when
         DiaryDetailResponse response = diaryService.displayDiary(user, 1L, 1L);
         //then
@@ -325,6 +327,8 @@ class DiaryServiceTest {
         assertEquals(response.images().size(), 1);
         assertEquals(response.commentCount(), 3);
         assertEquals(response.writer().nickname(), user.getNickname());
+        assertFalse(response.isCurrentUserLiked());
+        assertEquals(response.likeCount(), 5);
     }
 
     @Test
@@ -390,7 +394,7 @@ class DiaryServiceTest {
                 )));
         given(guardianRepository.existsByUserIdAndPetId(user.getId(), pet.getId()))
                 .willReturn(true);
-        given(diaryCommentCountRedisService.getDiaryCommentCountByDiaryId(any()))
+        given(diaryCommentRedisService.getDiaryCommentCountByDiaryId(any()))
                 .willReturn(3);
         //when
         Slice<DiaryGroupByDateResponse> response = diaryService.displayDiaries(user, 1L, 10, 10);

--- a/petlog-domain/src/main/java/com/ppp/domain/common/constant/CacheValue.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/common/constant/CacheValue.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum CacheValue {
     PET_SPACE_AUTHORITY("petSpaceAuthority"),
-    DIARY_COMMENT_COUNT("diaryCommentCount")
+    DIARY_COMMENT_COUNT("diaryCommentCount"),
+    DIARY_LIKE_COUNT("diaryLikeCount"),
+    DIARY_COMMENT_LIKE_COUNT("diaryCommentLikeCount")
     ;
 
     private final String value;

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryCommentRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryCommentRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface DiaryCommentRepository extends JpaRepository<DiaryComment, Long> {
     Optional<DiaryComment> findByIdAndIsDeletedFalse(Long id);
     List<DiaryComment> findByDiaryAndIsDeletedFalse(Diary diary);
+    boolean existsByIdAndIsDeletedFalse(Long id);
 }

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiaryRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     Optional<Diary> findByIdAndIsDeletedFalse(Long id);
     Slice<Diary> findByPetIdAndIsDeletedFalseOrderByIdDesc(Long petId, PageRequest pageRequest);
+    boolean existsByIdAndIsDeletedFalse(Long id);
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #27
> 다이어리, 다이어리 댓글 좋아요 기능을 구현합니다.

## 🔑 Key Changes
- build register or cancel the like on diary endpoint
- build register or cancel the like on diary comment endpoint
- apply fields related to the like in the response
- cache like counts
- integration test for check cache working well

## 📢 To Reviewers
