### PR TITLE
feat: add pet's guardians retrieval api for log, diary comment

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/guardian/controller/GuardianController.java
+++ b/petlog-api/src/main/java/com/ppp/api/guardian/controller/GuardianController.java
@@ -6,8 +6,10 @@ import com.ppp.api.guardian.dto.request.InviteGuardianRequest;
 import com.ppp.api.guardian.dto.response.GuardianResponse;
 import com.ppp.api.guardian.dto.response.GuardiansResponse;
 import com.ppp.api.guardian.service.GuardianService;
+import com.ppp.api.user.dto.response.UserResponse;
 import com.ppp.common.security.PrincipalDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -18,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "관리-공동집사(펫메이트 그룹)", description = "관리-공동집사 APIs")
 @Slf4j
@@ -66,8 +70,20 @@ public class GuardianController {
             @PathVariable Long petId,
             @RequestBody InviteGuardianRequest inviteGuardianRequest,
             @AuthenticationPrincipal PrincipalDetails principalDetails
-            ) {
+    ) {
         guardianService.inviteGuardian(petId, inviteGuardianRequest, principalDetails.getUser());
         return ResponseEntity.ok().build();
+    }
+
+
+    @Operation(summary = "반려 동물에 대한 공동 집사 리스트 조회 for Diary Comment, Log")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = {@Content(array = @ArraySchema(schema = @Schema(implementation = UserResponse.class)))}),
+            @ApiResponse(responseCode = "403", description = "기록 공간에 대한 권한 없음", content = {@Content(schema = @Schema(implementation = ExceptionResponse.class))})
+    })
+    @GetMapping("/v1/pets/{petId}/guardians")
+    public ResponseEntity<List<UserResponse>> displayGuardiansByPetId(@PathVariable Long petId,
+                                                                      @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(guardianService.displayGuardiansByPetId(principalDetails.getUser(), petId));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/guardian/exception/ErrorCode.java
+++ b/petlog-api/src/main/java/com/ppp/api/guardian/exception/ErrorCode.java
@@ -11,10 +11,10 @@ public enum ErrorCode {
     NOT_ALLOWED_DELETE_LEADER(HttpStatus.BAD_REQUEST, "GUARDIAN-0002", "다른 멤버가 있을 때 탈퇴할 수 없습니다."),
     NOT_INVITED_EMAIL(HttpStatus.BAD_REQUEST, "GUARDIAN-0003", "자신의 이메일은 초대가 불가능 합니다."),
     NOT_FOUND_INVITEE(HttpStatus.NOT_FOUND, "GUARDIAN-0004", "초대한 사용자를 찾을 수 없습니다."),
-    NOT_INVITED_ALREADY_GUARDIAN(HttpStatus.BAD_REQUEST,"GUARDIAN-0005" , "해당 반려동물의 공동집사입니다."),
-    NOT_INVITED(HttpStatus.BAD_REQUEST,"GUARDIAN-0006" , "초대가 불가능합니다. 다시 확인해주세요."),
-    NOT_DELETED_IF_READER(HttpStatus.BAD_REQUEST,"GUARDIAN-0007" , "그룹 생성자의 경우, 탈퇴는 관리자에게 문의해주세요."),
-    ;
+    NOT_INVITED_ALREADY_GUARDIAN(HttpStatus.BAD_REQUEST, "GUARDIAN-0005", "해당 반려동물의 공동집사입니다."),
+    NOT_INVITED(HttpStatus.BAD_REQUEST, "GUARDIAN-0006", "초대가 불가능합니다. 다시 확인해주세요."),
+    NOT_DELETED_IF_READER(HttpStatus.BAD_REQUEST, "GUARDIAN-0007", "그룹 생성자의 경우, 탈퇴는 관리자에게 문의해주세요."),
+    FORBIDDEN_PET_SPACE(HttpStatus.FORBIDDEN, "GUARDIAN-0008", "해당 공간에 대한 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/petlog-api/src/main/java/com/ppp/api/user/dto/response/UserResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/user/dto/response/UserResponse.java
@@ -2,6 +2,7 @@ package com.ppp.api.user.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.ppp.domain.user.User;
+import com.ppp.domain.user.UserDao;
 import com.ppp.domain.user.UserDocument;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
@@ -35,6 +36,14 @@ public record UserResponse(
                 .id(userDocument.getId())
                 .nickname(userDocument.getNickname())
                 .isCurrentUser(Objects.equals(userDocument.getId(), currentUserId))
+                .build();
+    }
+
+    public static UserResponse from(UserDao user, String currentUserId) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .isCurrentUser(Objects.equals(user.getId(), currentUserId))
                 .build();
     }
 

--- a/petlog-api/src/test/java/com/ppp/api/guardian/controller/GuardianControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/guardian/controller/GuardianControllerTest.java
@@ -1,0 +1,55 @@
+package com.ppp.api.guardian.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ppp.api.guardian.service.GuardianService;
+import com.ppp.api.test.WithMockCustomUser;
+import com.ppp.common.security.UserDetailsServiceImpl;
+import com.ppp.common.security.jwt.JwtAuthenticationFilter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GuardianController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class GuardianControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private GuardianService guardianService;
+
+    private static final String TOKEN = "Bearer token";
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기 리스트 조회 성공")
+    void displayDiaries_success() throws Exception {
+        //given
+        //when
+        mockMvc.perform(get("/api/v1/pets/{petId}/guardians", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
+
+}

--- a/petlog-api/src/test/java/com/ppp/api/guardian/service/GuardianServiceTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/guardian/service/GuardianServiceTest.java
@@ -1,0 +1,69 @@
+package com.ppp.api.guardian.service;
+
+import com.ppp.api.guardian.exception.GuardianException;
+import com.ppp.api.user.dto.response.UserResponse;
+import com.ppp.domain.guardian.repository.GuardianRepository;
+import com.ppp.domain.user.User;
+import com.ppp.domain.user.UserDao;
+import com.ppp.domain.user.repository.UserQuerydslRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.ppp.api.guardian.exception.ErrorCode.FORBIDDEN_PET_SPACE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GuardianServiceTest {
+    @Mock
+    private GuardianRepository guardianRepository;
+    @Mock
+    private UserQuerydslRepository userQuerydslRepository;
+    @InjectMocks
+    private GuardianService guardianService;
+
+    User user = User.builder()
+            .id("abcde1234")
+            .nickname("hi")
+            .build();
+
+    @Test
+    @DisplayName("반려 동물에 대한 공동 집사 리스트 조회 성공")
+    void displayGuardiansByPetId_success() {
+        //given
+        given(guardianRepository.existsByUserIdAndPetId(anyString(), anyLong()))
+                .willReturn(true);
+        given(userQuerydslRepository.findGuardianUserByPetId(anyLong()))
+                .willReturn(List.of(new UserDao("abcde1234", "hi"),
+                        new UserDao("qwerty1456", "체리엄마")));
+        //when
+        List<UserResponse> response = guardianService.displayGuardiansByPetId(user, 1L);
+        //then
+        assertEquals(response.get(0).id(), "abcde1234");
+        assertEquals(response.get(0).nickname(), "hi");
+        assertTrue(response.get(0).isCurrentUser());
+        assertEquals(response.get(1).id(), "qwerty1456");
+        assertEquals(response.get(1).nickname(), "체리엄마");
+        assertFalse(response.get(1).isCurrentUser());
+    }
+
+    @Test
+    @DisplayName("반려 동물에 대한 공동 집사 리스트 조회 실패-forbidden pet space")
+    void displayGuardiansByPetId_fail_FORBIDDEN_PET_SPACE() {
+        //given
+        given(guardianRepository.existsByUserIdAndPetId(anyString(), anyLong()))
+                .willReturn(false);
+        //when
+        GuardianException exception = assertThrows(GuardianException.class, () -> guardianService.displayGuardiansByPetId(user, 1L));
+        //then
+        assertEquals(exception.getCode(), FORBIDDEN_PET_SPACE.getCode());
+    }
+}

--- a/petlog-domain/build.gradle.kts
+++ b/petlog-domain/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.1.8" apply(false)
+    id("org.springframework.boot") version "3.1.8" apply (false)
     id("io.spring.dependency-management") version "1.1.4"
 }
 
@@ -22,6 +22,8 @@ dependencyManagement {
     }
 }
 
+var queryDslVersion = "5.0.0"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -30,8 +32,12 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-hibernate5-jakarta")
     implementation("io.hypersistence:hypersistence-utils-hibernate-62:3.7.1")
     implementation("org.springframework.data:spring-data-elasticsearch:5.1.8")
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
 }
 
-tasks.register("prepareKotlinBuildScriptModel"){}
+tasks.register("prepareKotlinBuildScriptModel") {}

--- a/petlog-domain/build.gradle.kts
+++ b/petlog-domain/build.gradle.kts
@@ -22,7 +22,6 @@ dependencyManagement {
     }
 }
 
-var queryDslVersion = "5.0.0"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")

--- a/petlog-domain/src/main/java/com/ppp/domain/common/config/QuerydslConfig.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/common/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.ppp.domain.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/user/UserDao.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/user/UserDao.java
@@ -1,0 +1,16 @@
+package com.ppp.domain.user;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+@Data
+public class UserDao {
+    private String id;
+    private String nickname;
+
+    @QueryProjection
+    public UserDao(String id, String nickname) {
+        this.id = id;
+        this.nickname = nickname;
+    }
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/user/repository/UserQuerydslRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/user/repository/UserQuerydslRepository.java
@@ -1,0 +1,26 @@
+package com.ppp.domain.user.repository;
+
+import com.ppp.domain.user.UserDao;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.ppp.domain.guardian.QGuardian.guardian;
+import static com.ppp.domain.user.QUser.user;
+import static com.querydsl.core.types.Projections.constructor;
+
+@Repository
+@RequiredArgsConstructor
+public class UserQuerydslRepository {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<UserDao> findGuardianUserByPetId(Long petId) {
+        return jpaQueryFactory.select(constructor(UserDao.class, user.id, user.nickname))
+                .from(guardian)
+                .leftJoin(guardian.user, user)
+                .where(guardian.pet.id.eq(petId))
+                .fetch();
+    }
+}


### PR DESCRIPTION
## 🔎 PR Description
- Close #73 
> add pet's guardians retrieval api for log, diary comment feature

## 🔑 Key Changes
-  build pet's guardians retrieval api endpoint
- set up Querydsl 

## 📢 To Reviewers
- I add Querydsl setting, so you may face difficulty to load QClass. When you have problem about Qclass, Just execute gradle `celan-build` in petlog-domain module
<img width="300" alt="스크린샷 2024-02-15 오후 9 11 30" src="https://github.com/ppp-team/my-petlog-server/assets/80521474/2a5c4d60-71d4-4d6b-b1b0-22c7586b1099">
