### PR TITLE
fix: modify diary comment keys used in redis more detailed

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryCommentRedisService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryCommentRedisService.java
@@ -40,12 +40,12 @@ public class DiaryCommentRedisService {
     }
 
     public boolean isDiaryCommentLikeExistByCommentIdAndUserId(Long commentId, String userId) {
-        return redisClient.isValueExistInSet(Domain.DIARY_COMMENT, commentId, userId);
+        return redisClient.isValueExistInSet(Domain.DIARY_COMMENT_LIKE, commentId, userId);
     }
 
     @Cacheable(value = "diaryCommentLikeCount")
     public Integer getLikeCountByCommentId(Long commentId) {
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT, commentId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, commentId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -53,8 +53,8 @@ public class DiaryCommentRedisService {
 
     @CachePut(value = "diaryCommentLikeCount", key = "#a0")
     public Integer registerLikeByCommentIdAndUserId(Long commentId, String userId) {
-        redisClient.addValueToSet(Domain.DIARY_COMMENT, commentId, userId);
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT, commentId);
+        redisClient.addValueToSet(Domain.DIARY_COMMENT_LIKE, commentId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, commentId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -62,8 +62,8 @@ public class DiaryCommentRedisService {
 
     @CachePut(value = "diaryCommentLikeCount", key = "#a0")
     public Integer cancelLikeByCommentIdAndUserId(Long commentId, String userId) {
-        redisClient.removeValueToSet(Domain.DIARY_COMMENT, commentId, userId);
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT, commentId);
+        redisClient.removeValueToSet(Domain.DIARY_COMMENT_LIKE, commentId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, commentId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -71,6 +71,6 @@ public class DiaryCommentRedisService {
 
     @CacheEvict(value = "diaryCommentLikeCount")
     public void deleteAllLikeByCommentId(Long commentId) {
-        redisClient.removeKeyToSet(Domain.DIARY_COMMENT, commentId);
+        redisClient.removeKeyToSet(Domain.DIARY_COMMENT_LIKE, commentId);
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryRedisService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiaryRedisService.java
@@ -14,12 +14,12 @@ public class DiaryRedisService {
     private final RedisClient redisClient;
 
     public boolean isLikeExistByDiaryIdAndUserId(Long diaryId, String userId) {
-        return redisClient.isValueExistInSet(Domain.DIARY, diaryId, userId);
+        return redisClient.isValueExistInSet(Domain.DIARY_LIKE, diaryId, userId);
     }
 
     @Cacheable(value = "diaryLikeCount")
     public Integer getLikeCountByDiaryId(Long diaryId) {
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_LIKE, diaryId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -27,8 +27,8 @@ public class DiaryRedisService {
 
     @CachePut(value = "diaryLikeCount", key = "#a0")
     public Integer registerLikeByDiaryIdAndUserId(Long diaryId, String userId) {
-        redisClient.addValueToSet(Domain.DIARY, diaryId, userId);
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        redisClient.addValueToSet(Domain.DIARY_LIKE, diaryId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_LIKE, diaryId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -36,8 +36,8 @@ public class DiaryRedisService {
 
     @CachePut(value = "diaryLikeCount", key = "#a0")
     public Integer cancelLikeByDiaryIdAndUserId(Long diaryId, String userId) {
-        redisClient.removeValueToSet(Domain.DIARY, diaryId, userId);
-        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY, diaryId);
+        redisClient.removeValueToSet(Domain.DIARY_LIKE, diaryId, userId);
+        Long likeCount = redisClient.getSizeOfSet(Domain.DIARY_LIKE, diaryId);
         assert likeCount != null;
 
         return likeCount.intValue();
@@ -45,6 +45,6 @@ public class DiaryRedisService {
 
     @CacheEvict(value = "diaryLikeCount")
     public void deleteAllLikeByDiaryId(Long diaryId) {
-        redisClient.removeKeyToSet(Domain.DIARY, diaryId);
+        redisClient.removeKeyToSet(Domain.DIARY_LIKE, diaryId);
     }
 }

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryCommentRedisServiceIntegrationTest.java
@@ -131,7 +131,7 @@ class DiaryCommentRedisServiceIntegrationTest {
     @DisplayName("다이어리 댓글 좋아요 개수 캐싱 성공")
     void cachingGetLikeCountByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, 1L))
                 .willReturn(1L);
         //when
         Integer cacheMiss = diaryCommentRedisService.getLikeCountByCommentId(1L);
@@ -149,7 +149,7 @@ class DiaryCommentRedisServiceIntegrationTest {
     @DisplayName("다이어리 댓글 좋아요 개수 캐싱 업데이트 성공")
     void cachingRegisterLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheUpdated = diaryCommentRedisService.registerLikeByCommentIdAndUserId(1L, "abcde");
@@ -165,7 +165,7 @@ class DiaryCommentRedisServiceIntegrationTest {
     @DisplayName("다이어리 댓글 좋아요 개수 캐싱 업데이트 성공")
     void cachingCancelLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheUpdated = diaryCommentRedisService.cancelLikeByCommentIdAndUserId(1L, "abcde");
@@ -181,7 +181,7 @@ class DiaryCommentRedisServiceIntegrationTest {
     @DisplayName("다이어리 댓글 좋아요 캐시 삭제 성공")
     void deleteAllLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_COMMENT_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheMiss = diaryCommentRedisService.getLikeCountByCommentId(1L);

--- a/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryRedisServiceIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/service/DiaryRedisServiceIntegrationTest.java
@@ -58,7 +58,7 @@ class DiaryRedisServiceIntegrationTest {
     @DisplayName("다이어리 좋아요 개수 캐싱 성공")
     void cachingGetLikeCountByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_LIKE, 1L))
                 .willReturn(1L);
         //when
         Integer cacheMiss = diaryRedisService.getLikeCountByDiaryId(1L);
@@ -76,7 +76,7 @@ class DiaryRedisServiceIntegrationTest {
     @DisplayName("다이어리 좋아요 개수 캐싱 업데이트 성공")
     void cachingRegisterLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheUpdated = diaryRedisService.registerLikeByDiaryIdAndUserId(1L, "abcde");
@@ -92,7 +92,7 @@ class DiaryRedisServiceIntegrationTest {
     @DisplayName("다이어리 좋아요 개수 캐싱 업데이트 성공")
     void cachingCancelLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheUpdated = diaryRedisService.cancelLikeByDiaryIdAndUserId(1L, "abcde");
@@ -108,7 +108,7 @@ class DiaryRedisServiceIntegrationTest {
     @DisplayName("다이어리 좋아요 캐시 삭제 성공")
     void deleteAllLikeByCommentId_success() {
         //given
-        given(redisClient.getSizeOfSet(Domain.DIARY, 1L))
+        given(redisClient.getSizeOfSet(Domain.DIARY_LIKE, 1L))
                 .willReturn(3L);
         //when
         Integer cacheMiss = diaryRedisService.getLikeCountByDiaryId(1L);

--- a/petlog-domain/src/main/java/com/ppp/domain/common/constant/Domain.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/common/constant/Domain.java
@@ -8,7 +8,9 @@ import lombok.RequiredArgsConstructor;
 public enum Domain {
     USER(false),
     DIARY(true),
+    DIARY_LIKE(false),
     DIARY_COMMENT(false),
+    DIARY_COMMENT_LIKE(false),
     PET(false);
     private final boolean hasVideo;
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #92 
> there is the bug that redis diary comment retrieval api occurred RedisSystemException. I think It's because key duplication between diary comment count value and diary comment like set.

## 🔑 Key Changes
-  change diary comment keys used in redis

## 📢 To Reviewers
