### PR TITLE
fix: modify cached data when guardian is deleted

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/guardian/service/GuardianService.java
+++ b/petlog-api/src/main/java/com/ppp/api/guardian/service/GuardianService.java
@@ -7,6 +7,7 @@ import com.ppp.api.guardian.exception.ErrorCode;
 import com.ppp.api.guardian.exception.GuardianException;
 import com.ppp.api.pet.exception.PetException;
 import com.ppp.api.user.dto.response.UserResponse;
+import com.ppp.common.service.CacheManageService;
 import com.ppp.domain.guardian.Guardian;
 import com.ppp.domain.guardian.constant.GuardianRole;
 import com.ppp.domain.guardian.constant.RepStatus;
@@ -40,6 +41,7 @@ public class GuardianService {
     private final PetRepository petRepository;
     private final InvitationRepository invitationRepository;
     private final UserQuerydslRepository userQuerydslRepository;
+    private final CacheManageService cacheManageService;
 
     public GuardiansResponse displayGuardians(Long petId, User user) {
         if (!guardianRepository.existsByPetIdAndUserId(petId, user.getId()))
@@ -74,6 +76,11 @@ public class GuardianService {
         } else if (isReaderGuardian(guardianMe)) {
             guardianRepository.deleteById(requestedGuardian.getId());
         }
+        deleteCachedGuardianAuthority(requestedGuardian.getUser().getId(), petId);
+    }
+
+    private void deleteCachedGuardianAuthority(String userId, Long petId) {
+        cacheManageService.deleteCachedPetSpaceAuthority(userId, petId);
     }
 
     private boolean isReaderGuardian(Guardian guardian) {

--- a/petlog-api/src/main/java/com/ppp/api/guardian/service/GuardianService.java
+++ b/petlog-api/src/main/java/com/ppp/api/guardian/service/GuardianService.java
@@ -44,7 +44,7 @@ public class GuardianService {
     private final CacheManageService cacheManageService;
 
     public GuardiansResponse displayGuardians(Long petId, User user) {
-        if (!guardianRepository.existsByPetIdAndUserId(petId, user.getId()))
+        if (!guardianRepository.existsByUserIdAndPetId(user.getId(), petId))
             throw new GuardianException(ErrorCode.GUARDIAN_NOT_FOUND);
 
         List<GuardianResponse> guardianResponseList = new ArrayList<>();
@@ -122,7 +122,7 @@ public class GuardianService {
     }
 
     public void validateIsGuardian(Long petId, String userId) {
-        if (guardianRepository.existsByPetIdAndUserId(petId, userId))
+        if (guardianRepository.existsByUserIdAndPetId(userId, petId))
             throw new GuardianException(ErrorCode.NOT_INVITED_ALREADY_GUARDIAN);
     }
 

--- a/petlog-api/src/main/java/com/ppp/api/pet/service/PetService.java
+++ b/petlog-api/src/main/java/com/ppp/api/pet/service/PetService.java
@@ -117,7 +117,7 @@ public class PetService {
 
     @Transactional
     public void updatePet(Long petId, PetRequest petRequest, User user, MultipartFile petImage) {
-        if(!guardianRepository.existsByPetIdAndUserId(petId, user.getId()))
+        if (!guardianRepository.existsByUserIdAndPetId(user.getId(), petId))
             throw new GuardianException(GUARDIAN_NOT_FOUND);
 
         Pet pet = petRepository.findByIdAndIsDeletedFalse(petId)

--- a/petlog-api/src/test/java/com/ppp/api/config/CacheIntegrationTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/config/CacheIntegrationTest.java
@@ -79,11 +79,6 @@ public class CacheIntegrationTest {
             .pet(pet)
             .user(userA).build();
 
-    Guardian guardianB = Guardian.builder()
-            .guardianRole(GuardianRole.MEMBER)
-            .pet(pet)
-            .user(userB).build();
-
 
     @BeforeEach
     void setUp() {

--- a/petlog-api/src/test/java/com/ppp/api/pet/service/PetServiceTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/pet/service/PetServiceTest.java
@@ -112,7 +112,7 @@ class PetServiceTest {
                 .registeredNumber("1234")
                 .build();
         when(petRepository.findByIdAndIsDeletedFalse(1L)).thenReturn(Optional.of(pet));
-        when(guardianRepository.existsByPetIdAndUserId(1L, user.getId())).thenReturn(true);
+        when(guardianRepository.existsByUserIdAndPetId(user.getId(), 1L)).thenReturn(true);
         //when
         petService.updatePet(1L, petRequest, user, null);
 

--- a/petlog-common/src/main/java/com/ppp/common/service/CacheManageService.java
+++ b/petlog-common/src/main/java/com/ppp/common/service/CacheManageService.java
@@ -1,0 +1,16 @@
+package com.ppp.common.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CacheManageService {
+    @CacheEvict(value = "petSpaceAuthority", key = "{#a0, #a1}")
+    public void deleteCachedPetSpaceAuthority(String userId, Long petId) {
+        log.info("Class : {}, Method : {}, CacheKey : {}", this.getClass(), "deleteCachedPetSpaceAuthority", userId + "," + petId);
+    }
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/guardian/repository/GuardianRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/guardian/repository/GuardianRepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface GuardianRepository extends JpaRepository<Guardian, Long> {
-    @Cacheable(value = "petSpaceAuthority", key = "{#a0, #a1}")
+    @Cacheable(value = "petSpaceAuthority", key = "{#a0, #a1}", unless = "#result == false")
     boolean existsByUserIdAndPetId(String userId, Long petId);
 
     boolean existsByPetIdAndGuardianRole(Long petId, GuardianRole guardianRole);

--- a/petlog-domain/src/main/java/com/ppp/domain/guardian/repository/GuardianRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/guardian/repository/GuardianRepository.java
@@ -23,5 +23,4 @@ public interface GuardianRepository extends JpaRepository<Guardian, Long> {
 
     Optional<Guardian> findByUserIdAndRepStatus(String id, RepStatus repStatus);
 
-    boolean existsByPetIdAndUserId(Long petId, String userId);
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #116 
> There is a data integrity problem because of cache when guardian is created or deleted.

## 🔑 Key Changes
- modify temporarily fixed code by @llsrrll96
- modify cached data when guardian is deleted
- modify pet authority cache condition that is always true

## 📢 To Reviewers
-  I tested pet's guardian retrieving api when guardian is created and deleted, but please double-check it works well.
