### PR TITLE
fix:  change ffmpeg command taking into account the aspect ratio

### DIFF
--- a/petlog-common/src/main/java/com/ppp/common/client/FfmpegClient.java
+++ b/petlog-common/src/main/java/com/ppp/common/client/FfmpegClient.java
@@ -44,7 +44,8 @@ public class FfmpegClient implements VideoConvertClient, ThumbnailExtractClient 
                             .overrideOutputFiles(true)
                             .setInput(inputPath.toString())
                             .addOutput(outputPath.toString())
-                            .addExtraArgs("-vf", "scale=-1:" + compressType.getResolution())
+                            .addExtraArgs("-vf", String.format("scale='if(gt(iw,ih),%d,-1)':'if(gt(iw,ih),-1,%d)'",
+                                    compressType.getResolution(), compressType.getResolution()))
                             .done(), progress -> log.info(getClass() + " : resolution proceeding " + progress)).run();
             Files.delete(inputPath);
 

--- a/petlog-domain/src/main/java/com/ppp/domain/common/constant/VideoCompressType.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/common/constant/VideoCompressType.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum VideoCompressType {
     LOW(480),
-    MEDIUM(540);
+    MEDIUM(512);
     private final int resolution;
 }


### PR DESCRIPTION
## 🔎 PR Description
- Close #118 
> there is a video upload error In the case of a video with a long horizontal length, so change ffmpeg command in view of the aspect ratio.

## 🔑 Key Changes
- change ffmpeg command taking into account the aspect ratio

## 📢 To Reviewers
