### PR TITLE
fix: change ffmpeg command to truncate decimals

### DIFF
--- a/petlog-common/src/main/java/com/ppp/common/client/FfmpegClient.java
+++ b/petlog-common/src/main/java/com/ppp/common/client/FfmpegClient.java
@@ -44,7 +44,7 @@ public class FfmpegClient implements VideoConvertClient, ThumbnailExtractClient 
                             .overrideOutputFiles(true)
                             .setInput(inputPath.toString())
                             .addOutput(outputPath.toString())
-                            .addExtraArgs("-vf", String.format("scale='if(gt(iw,ih),%d,-1)':'if(gt(iw,ih),-1,%d)'",
+                            .addExtraArgs("-vf", String.format("scale='if(gt(iw,ih),%d,trunc(oh*a/2)*2)':'if(gt(iw,ih),trunc(ow/a/2)*2,%d)'",
                                     compressType.getResolution(), compressType.getResolution()))
                             .done(), progress -> log.info(getClass() + " : resolution proceeding " + progress)).run();
             Files.delete(inputPath);


### PR DESCRIPTION
## 🔎 PR Description
- Close #121 
> I found out another issue about aspect ratio during resolution. An error occurred with the message like `width not divisible by 2 (277x480)`. I assume that it is a problem about decimals, so change command to truncate decimals.

## 🔑 Key Changes
- change ffmpeg command to truncate decimals

## 📢 To Reviewers
