### PR TITLE
feat: add api to retrieve most used terms in diary

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/config/CacheConfig.java
+++ b/petlog-api/src/main/java/com/ppp/api/config/CacheConfig.java
@@ -45,6 +45,8 @@ public class CacheConfig {
                 .withCacheConfiguration(DIARY_COMMENT_COUNT.getValue(),
                         RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(60)))
                 .withCacheConfiguration(DIARY_COMMENT_LIKE_COUNT.getValue(),
-                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(30)));
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(30)))
+                .withCacheConfiguration(DIARY_MOST_USED_TERMS.getValue(),
+                        RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(40)));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/controller/DiarySearchController.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/controller/DiarySearchController.java
@@ -1,6 +1,7 @@
 package com.ppp.api.diary.controller;
 
 import com.ppp.api.diary.dto.response.DiaryGroupByDateResponse;
+import com.ppp.api.diary.dto.response.DiaryMostUsedTermsResponse;
 import com.ppp.api.diary.service.DiarySearchService;
 import com.ppp.api.exception.ExceptionResponse;
 import com.ppp.common.security.PrincipalDetails;
@@ -38,5 +39,16 @@ public class DiarySearchController {
                                                                          @RequestParam(defaultValue = "5") int size,
                                                                          @AuthenticationPrincipal PrincipalDetails principalDetails) {
         return ResponseEntity.ok(diarySearchService.search(principalDetails.getUser(), keyword, petId, page, size));
+    }
+
+    @Operation(summary = "일기에서 자주 사용한 용어 조회")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", content = {@Content(array = @ArraySchema(schema = @Schema(implementation = DiaryMostUsedTermsResponse.class)))}),
+            @ApiResponse(responseCode = "403", description = "기록 공간에 대한 권한 없음", content = {@Content(schema = @Schema(implementation = ExceptionResponse.class))})
+    })
+    @GetMapping("/terms")
+    private ResponseEntity<DiaryMostUsedTermsResponse> findMostUsedTermsByPetId(@PathVariable Long petId,
+                                                                                @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        return ResponseEntity.ok(diarySearchService.findMostUsedTermsByPetId(principalDetails.getUser(), petId));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryMostUsedTermsResponse.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/dto/response/DiaryMostUsedTermsResponse.java
@@ -1,0 +1,19 @@
+package com.ppp.api.diary.dto.response;
+
+import com.ppp.domain.diary.dto.DiaryPopularTermsDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.Set;
+
+@Schema(description = "자주 사용한 용어")
+@Builder
+public record DiaryMostUsedTermsResponse(
+        Set<String> terms
+) {
+    public static DiaryMostUsedTermsResponse from(DiaryPopularTermsDto dto) {
+        return DiaryMostUsedTermsResponse.builder()
+                .terms(dto.getPopularTerms())
+                .build();
+    }
+}

--- a/petlog-api/src/main/java/com/ppp/api/diary/handler/DiaryCommentEventHandler.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/handler/DiaryCommentEventHandler.java
@@ -27,10 +27,7 @@ public class DiaryCommentEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDiaryCommentDeletedEvent(DiaryCommentDeletedEvent event) {
-        CompletableFuture.runAsync(() -> {
-                    log.info("Class : {}, Method : {}", this.getClass(), "handleDiaryCommentDeletedEvent");
-                })
-                .thenRunAsync(() -> diaryCommentRedisService.decreaseDiaryCommentCountByDiaryId(event.getDiaryId()))
+        CompletableFuture.runAsync(() -> diaryCommentRedisService.decreaseDiaryCommentCountByDiaryId(event.getDiaryId()))
                 .thenRunAsync(() -> diaryCommentRedisService.deleteAllLikeByCommentId(event.getCommentId()));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/handler/DiaryEventHandler.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/handler/DiaryEventHandler.java
@@ -30,30 +30,21 @@ public class DiaryEventHandler {
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDiaryCreatedEvent(DiaryCreatedEvent event) {
-        CompletableFuture.runAsync(() -> {
-                    log.info("Class : {}, Method : {}", this.getClass(), "handleDiaryCreatedEvent");
-                })
-                .thenRunAsync(() -> diarySearchService.save(diaryService.saveThumbnail(event.getDiaryId())))
+        CompletableFuture.runAsync(() -> diarySearchService.save(diaryService.saveThumbnail(event.getDiaryId())))
                 .thenRunAsync(() -> diaryCommentRedisService.setDiaryCommentCountByDiaryId(event.getDiaryId()));
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDiaryUpdatedEvent(DiaryUpdatedEvent event) {
-        CompletableFuture.runAsync(() -> {
-                    log.info("Class : {}, Method : {}", this.getClass(), "handleDiaryUpdatedEvent");
-                })
-                .thenRunAsync(() -> diarySearchService.update(diaryService.saveThumbnail(event.getDiaryId())))
+        CompletableFuture.runAsync(() -> diarySearchService.update(diaryService.saveThumbnail(event.getDiaryId())))
                 .thenRunAsync(() -> fileStorageManageService.deleteImages(event.getDeletedPaths()));
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleDiaryDeletedEvent(DiaryDeletedEvent event) {
-        CompletableFuture.runAsync(() -> {
-                    log.info("Class : {}, Method : {}", this.getClass(), "handleDiaryDeletedEvent");
-                })
-                .thenRunAsync(() -> diarySearchService.delete(event.getDiaryId()))
+        CompletableFuture.runAsync(() -> diarySearchService.delete(event.getDiaryId()))
                 .thenRunAsync(() -> diaryCommentRedisService.deleteDiaryCommentCountByDiaryId(event.getDiaryId()))
                 .thenRunAsync(() -> diaryRedisService.deleteAllLikeByDiaryId(event.getDiaryId()))
                 .thenRunAsync(() -> fileStorageManageService.deleteImages(event.getDeletedPaths()));

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiarySearchService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiarySearchService.java
@@ -1,12 +1,14 @@
 package com.ppp.api.diary.service;
 
 import com.ppp.api.diary.dto.response.DiaryGroupByDateResponse;
+import com.ppp.api.diary.dto.response.DiaryMostUsedTermsResponse;
 import com.ppp.api.diary.dto.response.DiaryResponse;
 import com.ppp.api.diary.exception.DiaryException;
 import com.ppp.api.user.exception.ErrorCode;
 import com.ppp.api.user.exception.UserException;
 import com.ppp.domain.diary.Diary;
 import com.ppp.domain.diary.DiaryDocument;
+import com.ppp.domain.diary.repository.DiarySearchQuerydslRepository;
 import com.ppp.domain.diary.repository.DiarySearchRepository;
 import com.ppp.domain.guardian.repository.GuardianRepository;
 import com.ppp.domain.user.User;
@@ -31,6 +33,7 @@ import static com.ppp.api.diary.exception.ErrorCode.FORBIDDEN_PET_SPACE;
 @RequiredArgsConstructor
 public class DiarySearchService {
     private final DiarySearchRepository diarySearchRepository;
+    private final DiarySearchQuerydslRepository diarySearchQuerydslRepository;
     private final DiaryCommentRedisService diaryCommentRedisService;
     private final GuardianRepository guardianRepository;
     private final UserRepository userRepository;
@@ -87,5 +90,10 @@ public class DiarySearchService {
         }
         content.add(DiaryGroupByDateResponse.of(prevDate, sameDaysDiaries));
         return new PageImpl<>(content, documentPage.getPageable(), documentPage.getTotalElements());
+    }
+
+    public DiaryMostUsedTermsResponse findMostUsedTermsByPetId(User user, Long petId) {
+        validateQueryDiaries(user, petId);
+        return DiaryMostUsedTermsResponse.from(diarySearchQuerydslRepository.findMostUsedTermsByPetId(petId));
     }
 }

--- a/petlog-api/src/main/java/com/ppp/api/diary/service/DiarySearchService.java
+++ b/petlog-api/src/main/java/com/ppp/api/diary/service/DiarySearchService.java
@@ -15,6 +15,7 @@ import com.ppp.domain.user.User;
 import com.ppp.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -92,6 +93,7 @@ public class DiarySearchService {
         return new PageImpl<>(content, documentPage.getPageable(), documentPage.getTotalElements());
     }
 
+    @Cacheable(value = "diaryMostUsedTerms", key = "#a1")
     public DiaryMostUsedTermsResponse findMostUsedTermsByPetId(User user, Long petId) {
         validateQueryDiaries(user, petId);
         return DiaryMostUsedTermsResponse.from(diarySearchQuerydslRepository.findMostUsedTermsByPetId(petId));

--- a/petlog-api/src/test/java/com/ppp/api/diary/controller/DiarySearchControllerTest.java
+++ b/petlog-api/src/test/java/com/ppp/api/diary/controller/DiarySearchControllerTest.java
@@ -53,4 +53,18 @@ class DiarySearchControllerTest {
                 .andExpect(status().isOk());
         //then
     }
+
+    @Test
+    @WithMockCustomUser
+    @DisplayName("일기에서 자주 사용한 용어 조회")
+    void findMostUsedTermsByPetId_success() throws Exception {
+        //given
+        //when
+        mockMvc.perform(get("/api/v1/pets/{petId}/diaries/search/terms", 1L)
+                        .header("Authorization", TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        //then
+    }
 }

--- a/petlog-domain/src/main/java/com/ppp/domain/common/constant/CacheValue.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/common/constant/CacheValue.java
@@ -9,7 +9,8 @@ public enum CacheValue {
     PET_SPACE_AUTHORITY("petSpaceAuthority"),
     DIARY_COMMENT_COUNT("diaryCommentCount"),
     DIARY_LIKE_COUNT("diaryLikeCount"),
-    DIARY_COMMENT_LIKE_COUNT("diaryCommentLikeCount")
+    DIARY_COMMENT_LIKE_COUNT("diaryCommentLikeCount"),
+    DIARY_MOST_USED_TERMS("diaryMostUsedTerms")
     ;
 
     private final String value;

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/dto/DiaryPopularTermsDto.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/dto/DiaryPopularTermsDto.java
@@ -1,0 +1,23 @@
+package com.ppp.domain.diary.dto;
+
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class DiaryPopularTermsDto {
+    private final Set<String> popularTerms;
+
+    public DiaryPopularTermsDto(SearchResponse<Void> searchResponse) {
+        List<StringTermsBucket> buckets = searchResponse.aggregations().get("title_word").sterms().buckets().array();
+        buckets.addAll(searchResponse.aggregations().get("title_word").sterms().buckets().array());
+        popularTerms = buckets.stream().map(bucket -> bucket.key().stringValue())
+                .collect(Collectors.toSet());
+    }
+}

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/dto/DiaryPopularTermsDto.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/dto/DiaryPopularTermsDto.java
@@ -15,8 +15,8 @@ public class DiaryPopularTermsDto {
     private final Set<String> popularTerms;
 
     public DiaryPopularTermsDto(SearchResponse<Void> searchResponse) {
-        List<StringTermsBucket> buckets = searchResponse.aggregations().get("title_word").sterms().buckets().array();
-        buckets.addAll(searchResponse.aggregations().get("title_word").sterms().buckets().array());
+        List<StringTermsBucket> buckets = searchResponse.aggregations().get("title_terms").sterms().buckets().array();
+        buckets.addAll(searchResponse.aggregations().get("content_terms").sterms().buckets().array());
         popularTerms = buckets.stream().map(bucket -> bucket.key().stringValue())
                 .collect(Collectors.toSet());
     }

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiarySearchQuerydslRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiarySearchQuerydslRepository.java
@@ -22,8 +22,8 @@ public class DiarySearchQuerydslRepository {
             return new DiaryPopularTermsDto(elasticsearchClient.search(new SearchRequest.Builder()
                     .size(0)
                     .query(petIdEq(petId))
-                    .aggregations("title_word", fieldTermsAggregation("title"))
-                    .aggregations("content_word", fieldTermsAggregation("content"))
+                    .aggregations("title_terms", fieldTermsAggregation("title"))
+                    .aggregations("content_terms", fieldTermsAggregation("content"))
                     .build(), Void.class));
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiarySearchQuerydslRepository.java
+++ b/petlog-domain/src/main/java/com/ppp/domain/diary/repository/DiarySearchQuerydslRepository.java
@@ -1,0 +1,45 @@
+package com.ppp.domain.diary.repository;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.TermsAggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import com.ppp.domain.diary.dto.DiaryPopularTermsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+
+@Repository
+@RequiredArgsConstructor
+public class DiarySearchQuerydslRepository {
+    private final ElasticsearchClient elasticsearchClient;
+
+    public DiaryPopularTermsDto findMostUsedTermsByPetId(Long petId) {
+        try {
+            return new DiaryPopularTermsDto(elasticsearchClient.search(new SearchRequest.Builder()
+                    .size(0)
+                    .query(petIdEq(petId))
+                    .aggregations("title_word", fieldTermsAggregation("title"))
+                    .aggregations("content_word", fieldTermsAggregation("content"))
+                    .build(), Void.class));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Query petIdEq(Long petId) {
+        return new MatchQuery.Builder()
+                .field("petId")
+                .query(petId)
+                .build()._toQuery();
+    }
+
+    private Aggregation fieldTermsAggregation(String fieldName) {
+        return new TermsAggregation.Builder().field(fieldName)
+                .minDocCount(10)
+                .build()._toAggregation();
+    }
+}


### PR DESCRIPTION
## 🔎 PR Description
- Close #127 
> add api retrieving most used terms in diary

## 🔑 Key Changes
- set up nori analyzer in elastic search to tokenize korean
- make elastic search query to aggregate count of terms in diary
- add api to retrieve most used terms in diary
- apply cache to retrieving most used term in diary for optimization

## 📢 To Reviewers
