### PR TITLE
fix: delete cached pet subscription info when the pet space is deleted

### DIFF
--- a/petlog-api/src/main/java/com/ppp/api/pet/service/PetService.java
+++ b/petlog-api/src/main/java/com/ppp/api/pet/service/PetService.java
@@ -7,6 +7,7 @@ import com.ppp.api.pet.dto.response.MyPetResponse;
 import com.ppp.api.pet.dto.response.MyPetsResponse;
 import com.ppp.api.pet.exception.ErrorCode;
 import com.ppp.api.pet.exception.PetException;
+import com.ppp.common.service.CacheManageService;
 import com.ppp.common.service.FileStorageManageService;
 import com.ppp.common.service.ThumbnailService;
 import com.ppp.domain.common.constant.Domain;
@@ -49,6 +50,7 @@ public class PetService {
     private final GuardianRepository guardianRepository;
     private final ThumbnailService thumbnailService;
     private final SubscriptionRepository subscriptionRepository;
+    private final CacheManageService cacheManageService;
 
     @Transactional
     public void createPet(PetRequest petRequest, User user, MultipartFile petImage) {
@@ -180,8 +182,8 @@ public class PetService {
     private void deleteSubscriptionsOfPet(Long petId) {
         List<Subscription> subscriptions = subscriptionRepository.findByPetId(petId);
         if (!subscriptions.isEmpty()) {
-            List<Long> subscriptionIds = subscriptions.stream().map(subscription -> subscription.getId()).collect(Collectors.toList());
-            subscriptionRepository.deleteAllByIdInBatch(subscriptionIds);
+            subscriptions.forEach(s -> cacheManageService.deleteCachedSubscriptionInfo(s.getSubscriber().getId()));
+            subscriptionRepository.deleteAllInBatch(subscriptions);
         }
     }
 


### PR DESCRIPTION
## 🔎 PR Description
- Close #181 
> delete cached pet subscription info when the pet space is deleted

## 🔑 Key Changes
- delete cached pet subscription info when the pet space is deleted

## 📢 To Reviewers

